### PR TITLE
rm height for selectize (multiple selection)

### DIFF
--- a/R/dashboardthemes.R
+++ b/R/dashboardthemes.R
@@ -917,7 +917,6 @@ shinyDashboardThemeDIY <- function(appFontFamily, appFontColor, logoBackColor, b
             color: ', appFontColor, ';
             border-color: ', textboxBorderColor, ';
             border-radius: ', textboxBorderRadius, 'px;
-            height: ', textboxHeight, 'px;
             min-height: ', textboxHeight, 'px;
             padding: ', textboxPadding, ';
           }


### PR DESCRIPTION
Hi,

Thanks for this great and usefull package. I've observed and fixed that multiple ``selectInput`` are not fully display. Seems due to ``height`` argument : 

with actual css : 

![with_height](https://user-images.githubusercontent.com/8750326/39636355-3c0bef38-4fc0-11e8-9641-0a6d5877bcd2.png)

just removing height

![without_height](https://user-images.githubusercontent.com/8750326/39636382-4eb3f644-4fc0-11e8-883a-4b94c339734f.png)

