### PR TITLE
UI fix when there are nested menu items

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dashboardthemes
 Type: Package
 Title: Customise the appearance of Shiny dashboard applications using themes
-Version: 1.0.5
+Version: 1.0.6
 Authors@R: person("Nik", "Lilovski", email = "nik.lilovski@outlook.com",
                   role = c("aut", "cre"))
 Maintainer: Nik Lilovski <nik.lilovski@outlook.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ### dashboardthemes ----------------------------------------
 
+### v1.0.6
+* Fixed a UI bug where submenu items would incorrectly receive the "selected" colour by default instead of only on selection. (#19)
+
 ### v1.0.5
 * Fixed small bug with multi-line selectize drop-box height cutting off - now set to auto by default.
 

--- a/R/dashboardthemes.R
+++ b/R/dashboardthemes.R
@@ -657,7 +657,7 @@ shinyDashboardThemeDIY <- function(
           }
 
           /* sidebar: tab selected */
-          .skin-blue .main-sidebar .sidebar .sidebar-menu .active a {
+          .skin-blue .main-sidebar .sidebar .sidebar-menu .active > a {
             color: ', sidebarTabTextColorSelected, ';
             font-size: ', sidebarTabTextSize, 'px;
             border-radius: ', sidebarTabRadiusSelected, ';


### PR DESCRIPTION
Previously when there were nested menu items, all the submenus would have the "selected" colour by default until one of them is clicked. This fixes that so that only a submenu that's actually selected will show that colour.